### PR TITLE
Add Automatic Text Segmentation for Long Input Handling

### DIFF
--- a/Sources/OtosakuTTS-iOS/OtosakuTTSError.swift
+++ b/Sources/OtosakuTTS-iOS/OtosakuTTSError.swift
@@ -14,7 +14,8 @@ public enum OtosakuTTSError: LocalizedError {
     case invalidTokensFile
     case invalidDictionaryFile
     case emptyInput
-    
+    case inputTooLong(Int)
+
     public var errorDescription: String? {
         switch self {
         case .modelLoadingFailed(let model):
@@ -33,6 +34,8 @@ public enum OtosakuTTSError: LocalizedError {
             return "Invalid or missing dictionary file"
         case .emptyInput:
             return "Input text is empty"
+        case .inputTooLong(let length):
+            return "Input text is too long (\(length) tokens). Single sentence must be within 240 tokens."
         }
     }
 }

--- a/Sources/OtosakuTTS-iOS/OtosakuTTS_iOS.swift
+++ b/Sources/OtosakuTTS-iOS/OtosakuTTS_iOS.swift
@@ -6,11 +6,15 @@ import CoreML
 import AVFoundation
 
 public class OtosakuTTS {
-    
+
     private let fastPitch: MLModel
     private let hifiGAN: MLModel
     private let tokenizer: Tokenizer
     private let audioFormat: AVAudioFormat
+
+    // Model input length constraints
+    private let minTokenLength = 2
+    private let maxTokenLength = 240
     
     public init(modelDirectoryURL: URL, computeUnits: MLComputeUnits = .all) throws {
         let configuration = MLModelConfiguration()
@@ -55,28 +59,167 @@ public class OtosakuTTS {
         guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw OtosakuTTSError.emptyInput
         }
-        
+
+        // Segment text by sentence boundaries
+        let segments = segmentText(text)
+
+        // If only one segment, process directly
+        if segments.count == 1 {
+            return try generateSingleSegment(segments[0])
+        }
+
+        // Process multiple segments and concatenate
+        var buffers: [AVAudioPCMBuffer] = []
+        for segment in segments {
+            let buffer = try generateSingleSegment(segment)
+            buffers.append(buffer)
+        }
+
+        return try concatenateBuffers(buffers)
+    }
+
+    private func generateSingleSegment(_ text: String) throws -> AVAudioPCMBuffer {
         let phoneIds = tokenizer.encode(text)
-        
+
+        // Check length constraints
+        guard phoneIds.count >= minTokenLength else {
+            throw OtosakuTTSError.emptyInput
+        }
+
+        guard phoneIds.count <= maxTokenLength else {
+            throw OtosakuTTSError.inputTooLong(phoneIds.count)
+        }
+
         let phones = try makeMultiArray(from: phoneIds)
-        
+
         let fastPitchInput = try MLDictionaryFeatureProvider(dictionary: ["x": phones])
         let fastPitchOutput = try fastPitch.prediction(from: fastPitchInput)
-        
+
         guard let spec = fastPitchOutput.featureValue(for: "spec")?.multiArrayValue else {
             throw OtosakuTTSError.specGenerationFailed
         }
-        
+
         let hifiGANInput = try MLDictionaryFeatureProvider(dictionary: ["x": spec])
         let hifiGANOutput = try hifiGAN.prediction(from: hifiGANInput)
-        
+
         guard let waveform = hifiGANOutput.featureValue(for: "waveform")?.multiArrayValue else {
             throw OtosakuTTSError.waveformGenerationFailed
         }
-        
+
         return try createAudioBuffer(from: waveform)
     }
     
+    private func segmentText(_ text: String) -> [String] {
+        // Split by sentence boundaries (period, question mark, exclamation mark)
+        let sentencePattern = #"[^.!?。!?]+[.!?。!?]+"#
+        let regex = try! NSRegularExpression(pattern: sentencePattern)
+        let matches = regex.matches(in: text, range: NSRange(text.startIndex..., in: text))
+
+        var segments: [String] = []
+
+        for match in matches {
+            if let range = Range(match.range, in: text) {
+                let sentence = String(text[range]).trimmingCharacters(in: .whitespacesAndNewlines)
+                if !sentence.isEmpty {
+                    // Check if this sentence fits within token limits
+                    let phoneIds = tokenizer.encode(sentence)
+                    if phoneIds.count <= maxTokenLength {
+                        segments.append(sentence)
+                    } else {
+                        // If a single sentence is too long, try splitting by commas
+                        let subSegments = segmentByCommas(sentence)
+                        segments.append(contentsOf: subSegments)
+                    }
+                }
+            }
+        }
+
+        // Handle any remaining text without punctuation
+        if segments.isEmpty {
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                let phoneIds = tokenizer.encode(trimmed)
+                if phoneIds.count <= maxTokenLength {
+                    segments.append(trimmed)
+                } else {
+                    // Try splitting by commas
+                    segments = segmentByCommas(trimmed)
+                }
+            }
+        }
+
+        return segments.isEmpty ? [text] : segments
+    }
+
+    private func segmentByCommas(_ text: String) -> [String] {
+        let parts = text.components(separatedBy: CharacterSet(charactersIn: ",，、"))
+        var segments: [String] = []
+        var currentSegment = ""
+
+        for part in parts {
+            let trimmed = part.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty { continue }
+
+            let testSegment = currentSegment.isEmpty ? trimmed : currentSegment + ", " + trimmed
+            let phoneIds = tokenizer.encode(testSegment)
+
+            if phoneIds.count <= maxTokenLength {
+                currentSegment = testSegment
+            } else {
+                // If current segment has content, save it
+                if !currentSegment.isEmpty {
+                    segments.append(currentSegment)
+                }
+
+                // Check if the trimmed part itself is too long
+                let trimmedPhoneIds = tokenizer.encode(trimmed)
+                if trimmedPhoneIds.count > maxTokenLength {
+                    // Last resort: split by words
+                    let wordSegments = segmentByWords(trimmed)
+                    segments.append(contentsOf: wordSegments)
+                    currentSegment = ""
+                } else {
+                    currentSegment = trimmed
+                }
+            }
+        }
+
+        if !currentSegment.isEmpty {
+            segments.append(currentSegment)
+        }
+
+        return segments
+    }
+
+    private func segmentByWords(_ text: String) -> [String] {
+        let words = text.components(separatedBy: .whitespaces).filter { !$0.isEmpty }
+        var segments: [String] = []
+        var currentSegment = ""
+
+        for word in words {
+            let testSegment = currentSegment.isEmpty ? word : currentSegment + " " + word
+            let phoneIds = tokenizer.encode(testSegment)
+
+            if phoneIds.count <= maxTokenLength {
+                currentSegment = testSegment
+            } else {
+                if !currentSegment.isEmpty {
+                    segments.append(currentSegment)
+                }
+
+                // If a single word is too long, we have to accept it and let it fail
+                // This is an extreme edge case (a word with 240+ phonemes)
+                currentSegment = word
+            }
+        }
+
+        if !currentSegment.isEmpty {
+            segments.append(currentSegment)
+        }
+
+        return segments.isEmpty ? [text] : segments
+    }
+
     private func makeMultiArray(from ints: [Int]) throws -> MLMultiArray {
         let arr = try MLMultiArray(shape: [1, NSNumber(value: ints.count)], dataType: .int32)
         for (i, v) in ints.enumerated() { 
@@ -85,23 +228,68 @@ public class OtosakuTTS {
         return arr
     }
     
+    private func concatenateBuffers(_ buffers: [AVAudioPCMBuffer]) throws -> AVAudioPCMBuffer {
+        guard !buffers.isEmpty else {
+            throw OtosakuTTSError.audioBufferCreationFailed
+        }
+
+        // Calculate total length with silence padding between segments
+        let silenceSamples = Int(audioFormat.sampleRate * 0.3) // 300ms silence between sentences
+        let totalLength = buffers.reduce(0) { $0 + Int($1.frameLength) } + (buffers.count - 1) * silenceSamples
+
+        guard let concatenatedBuffer = AVAudioPCMBuffer(
+            pcmFormat: audioFormat,
+            frameCapacity: AVAudioFrameCount(totalLength)
+        ) else {
+            throw OtosakuTTSError.audioBufferCreationFailed
+        }
+
+        concatenatedBuffer.frameLength = AVAudioFrameCount(totalLength)
+
+        guard let outputData = concatenatedBuffer.floatChannelData?[0] else {
+            throw OtosakuTTSError.audioBufferCreationFailed
+        }
+
+        var currentPosition = 0
+
+        for (index, buffer) in buffers.enumerated() {
+            guard let inputData = buffer.floatChannelData?[0] else {
+                throw OtosakuTTSError.audioBufferCreationFailed
+            }
+
+            let frameCount = Int(buffer.frameLength)
+
+            // Copy audio data
+            memcpy(outputData.advanced(by: currentPosition), inputData, frameCount * MemoryLayout<Float>.size)
+            currentPosition += frameCount
+
+            // Add silence between segments (except after the last segment)
+            if index < buffers.count - 1 {
+                // Silence is already zero-initialized, just skip ahead
+                currentPosition += silenceSamples
+            }
+        }
+
+        return concatenatedBuffer
+    }
+
     private func createAudioBuffer(from array: MLMultiArray) throws -> AVAudioPCMBuffer {
         let length = array.count
         var floats = [Float](repeating: 0, count: length)
-        for i in 0..<length { 
-            floats[i] = array[i].floatValue 
+        for i in 0..<length {
+            floats[i] = array[i].floatValue
         }
-        
+
         guard let buffer = AVAudioPCMBuffer(
             pcmFormat: audioFormat,
             frameCapacity: AVAudioFrameCount(length)
         ) else {
             throw OtosakuTTSError.audioBufferCreationFailed
         }
-        
+
         buffer.frameLength = buffer.frameCapacity
         buffer.floatChannelData!.pointee.update(from: &floats, count: length)
-        
+
         return buffer
     }
 }


### PR DESCRIPTION
Error info:
Failed to synthesize speech: Size (273) of dimension (1) is not in allowed range (2..240)


---

**Problem**

  The TTS models have a strict input length constraint of 2-240 tokens. When input text exceeded this limit, synthesis would fail with: Size (273) of dimension (1) is not in allowed range
   (2..240)

  **Solution**

  Implemented a multi-level text segmentation strategy that automatically handles long input text:

  Three-tier fallback mechanism:
  1. Sentence-level segmentation - Split by sentence boundaries (.!?。!?)
  2. Comma-level segmentation - For long sentences, split by commas (,，、)
  3. Word-level segmentation - For continuous text without punctuation, split by whitespace

  Each level validates token count and only proceeds to the next level if needed. Segments are synthesized independently and concatenated with 300ms natural pauses between them.

  **Key Features**

  - Automatic handling of texts exceeding 240-token limit
  - Smart merging to maximize segment length within constraints
  - Natural sentence pauses (300ms) between concatenated segments
  - Maintains backward compatibility - short texts process unchanged
  - Clear error messages for edge cases (e.g., single word >240 tokens)

  **Changes**

  - Added inputTooLong error case with descriptive message
  - Added segmentText() for sentence boundary detection
  - Added segmentByCommas() for comma-based splitting
  - Added segmentByWords() as final fallback for continuous text
  - Added concatenateBuffers() for seamless audio merging
  - Refactored generate() to handle multi-segment synthesis